### PR TITLE
Rename 'memory_account' to 'memory'

### DIFF
--- a/clients/js/src/generated/instructions/memoryClose.ts
+++ b/clients/js/src/generated/instructions/memoryClose.ts
@@ -41,7 +41,7 @@ export type MemoryCloseInstruction<
     | string
     | IAccountMeta<string> = 'L1TEVtgA75k273wWz1s6XMmDhQY5i3MwcvKb4VbZzfK',
   TAccountPayer extends string | IAccountMeta<string> = string,
-  TAccountMemoryAccount extends string | IAccountMeta<string> = string,
+  TAccountMemory extends string | IAccountMeta<string> = string,
   TRemainingAccounts extends Array<IAccountMeta<string>> = []
 > = IInstruction<TProgram> &
   IInstructionWithData<Uint8Array> &
@@ -53,9 +53,9 @@ export type MemoryCloseInstruction<
       TAccountPayer extends string
         ? ReadonlySignerAccount<TAccountPayer>
         : TAccountPayer,
-      TAccountMemoryAccount extends string
-        ? WritableAccount<TAccountMemoryAccount>
-        : TAccountMemoryAccount,
+      TAccountMemory extends string
+        ? WritableAccount<TAccountMemory>
+        : TAccountMemory,
       ...TRemainingAccounts
     ]
   >;
@@ -66,7 +66,7 @@ export type MemoryCloseInstructionWithSigners<
     | string
     | IAccountMeta<string> = 'L1TEVtgA75k273wWz1s6XMmDhQY5i3MwcvKb4VbZzfK',
   TAccountPayer extends string | IAccountMeta<string> = string,
-  TAccountMemoryAccount extends string | IAccountMeta<string> = string,
+  TAccountMemory extends string | IAccountMeta<string> = string,
   TRemainingAccounts extends Array<IAccountMeta<string>> = []
 > = IInstruction<TProgram> &
   IInstructionWithData<Uint8Array> &
@@ -79,30 +79,30 @@ export type MemoryCloseInstructionWithSigners<
         ? ReadonlySignerAccount<TAccountPayer> &
             IAccountSignerMeta<TAccountPayer>
         : TAccountPayer,
-      TAccountMemoryAccount extends string
-        ? WritableAccount<TAccountMemoryAccount>
-        : TAccountMemoryAccount,
+      TAccountMemory extends string
+        ? WritableAccount<TAccountMemory>
+        : TAccountMemory,
       ...TRemainingAccounts
     ]
   >;
 
 export type MemoryCloseInstructionData = {
   discriminator: number;
-  memoryIndex: number;
-  memoryAccountBump: number;
+  memoryId: number;
+  memoryBump: number;
 };
 
 export type MemoryCloseInstructionDataArgs = {
-  memoryIndex: number;
-  memoryAccountBump: number;
+  memoryId: number;
+  memoryBump: number;
 };
 
 export function getMemoryCloseInstructionDataEncoder(): Encoder<MemoryCloseInstructionDataArgs> {
   return mapEncoder(
     getStructEncoder([
       ['discriminator', getU8Encoder()],
-      ['memoryIndex', getU8Encoder()],
-      ['memoryAccountBump', getU8Encoder()],
+      ['memoryId', getU8Encoder()],
+      ['memoryBump', getU8Encoder()],
     ]),
     (value) => ({ ...value, discriminator: 1 })
   );
@@ -111,8 +111,8 @@ export function getMemoryCloseInstructionDataEncoder(): Encoder<MemoryCloseInstr
 export function getMemoryCloseInstructionDataDecoder(): Decoder<MemoryCloseInstructionData> {
   return getStructDecoder([
     ['discriminator', getU8Decoder()],
-    ['memoryIndex', getU8Decoder()],
-    ['memoryAccountBump', getU8Decoder()],
+    ['memoryId', getU8Decoder()],
+    ['memoryBump', getU8Decoder()],
   ]);
 }
 
@@ -129,78 +129,70 @@ export function getMemoryCloseInstructionDataCodec(): Codec<
 export type MemoryCloseInput<
   TAccountProgramId extends string,
   TAccountPayer extends string,
-  TAccountMemoryAccount extends string
+  TAccountMemory extends string
 > = {
   /** Lighthouse program */
   programId?: Address<TAccountProgramId>;
   /** Payer account */
   payer: Address<TAccountPayer>;
   /** Memory account */
-  memoryAccount: Address<TAccountMemoryAccount>;
-  memoryIndex: MemoryCloseInstructionDataArgs['memoryIndex'];
-  memoryAccountBump: MemoryCloseInstructionDataArgs['memoryAccountBump'];
+  memory: Address<TAccountMemory>;
+  memoryId: MemoryCloseInstructionDataArgs['memoryId'];
+  memoryBump: MemoryCloseInstructionDataArgs['memoryBump'];
 };
 
 export type MemoryCloseInputWithSigners<
   TAccountProgramId extends string,
   TAccountPayer extends string,
-  TAccountMemoryAccount extends string
+  TAccountMemory extends string
 > = {
   /** Lighthouse program */
   programId?: Address<TAccountProgramId>;
   /** Payer account */
   payer: TransactionSigner<TAccountPayer>;
   /** Memory account */
-  memoryAccount: Address<TAccountMemoryAccount>;
-  memoryIndex: MemoryCloseInstructionDataArgs['memoryIndex'];
-  memoryAccountBump: MemoryCloseInstructionDataArgs['memoryAccountBump'];
+  memory: Address<TAccountMemory>;
+  memoryId: MemoryCloseInstructionDataArgs['memoryId'];
+  memoryBump: MemoryCloseInstructionDataArgs['memoryBump'];
 };
 
 export function getMemoryCloseInstruction<
   TAccountProgramId extends string,
   TAccountPayer extends string,
-  TAccountMemoryAccount extends string,
+  TAccountMemory extends string,
   TProgram extends string = 'L1TEVtgA75k273wWz1s6XMmDhQY5i3MwcvKb4VbZzfK'
 >(
   input: MemoryCloseInputWithSigners<
     TAccountProgramId,
     TAccountPayer,
-    TAccountMemoryAccount
+    TAccountMemory
   >
 ): MemoryCloseInstructionWithSigners<
   TProgram,
   TAccountProgramId,
   TAccountPayer,
-  TAccountMemoryAccount
+  TAccountMemory
 >;
 export function getMemoryCloseInstruction<
   TAccountProgramId extends string,
   TAccountPayer extends string,
-  TAccountMemoryAccount extends string,
+  TAccountMemory extends string,
   TProgram extends string = 'L1TEVtgA75k273wWz1s6XMmDhQY5i3MwcvKb4VbZzfK'
 >(
-  input: MemoryCloseInput<
-    TAccountProgramId,
-    TAccountPayer,
-    TAccountMemoryAccount
-  >
+  input: MemoryCloseInput<TAccountProgramId, TAccountPayer, TAccountMemory>
 ): MemoryCloseInstruction<
   TProgram,
   TAccountProgramId,
   TAccountPayer,
-  TAccountMemoryAccount
+  TAccountMemory
 >;
 export function getMemoryCloseInstruction<
   TAccountProgramId extends string,
   TAccountPayer extends string,
-  TAccountMemoryAccount extends string,
+  TAccountMemory extends string,
   TProgram extends string = 'L1TEVtgA75k273wWz1s6XMmDhQY5i3MwcvKb4VbZzfK'
 >(
-  input: MemoryCloseInput<
-    TAccountProgramId,
-    TAccountPayer,
-    TAccountMemoryAccount
-  >
+  input: MemoryCloseInput<TAccountProgramId, TAccountPayer, TAccountMemory>
 ): IInstruction {
   // Program address.
   const programAddress =
@@ -212,13 +204,13 @@ export function getMemoryCloseInstruction<
       TProgram,
       TAccountProgramId,
       TAccountPayer,
-      TAccountMemoryAccount
+      TAccountMemory
     >
   >[0];
   const accounts: Record<keyof AccountMetas, ResolvedAccount> = {
     programId: { value: input.programId ?? null, isWritable: false },
     payer: { value: input.payer ?? null, isWritable: false },
-    memoryAccount: { value: input.memoryAccount ?? null, isWritable: true },
+    memory: { value: input.memory ?? null, isWritable: true },
   };
 
   // Original args.
@@ -252,7 +244,7 @@ export function getMemoryCloseInstructionRaw<
     | string
     | IAccountMeta<string> = 'L1TEVtgA75k273wWz1s6XMmDhQY5i3MwcvKb4VbZzfK',
   TAccountPayer extends string | IAccountMeta<string> = string,
-  TAccountMemoryAccount extends string | IAccountMeta<string> = string,
+  TAccountMemory extends string | IAccountMeta<string> = string,
   TRemainingAccounts extends Array<IAccountMeta<string>> = []
 >(
   accounts: {
@@ -262,9 +254,9 @@ export function getMemoryCloseInstructionRaw<
     payer: TAccountPayer extends string
       ? Address<TAccountPayer>
       : TAccountPayer;
-    memoryAccount: TAccountMemoryAccount extends string
-      ? Address<TAccountMemoryAccount>
-      : TAccountMemoryAccount;
+    memory: TAccountMemory extends string
+      ? Address<TAccountMemory>
+      : TAccountMemory;
   },
   args: MemoryCloseInstructionDataArgs,
   programAddress: Address<TProgram> = 'L1TEVtgA75k273wWz1s6XMmDhQY5i3MwcvKb4VbZzfK' as Address<TProgram>,
@@ -281,7 +273,7 @@ export function getMemoryCloseInstructionRaw<
         AccountRole.READONLY
       ),
       accountMetaWithDefault(accounts.payer, AccountRole.READONLY_SIGNER),
-      accountMetaWithDefault(accounts.memoryAccount, AccountRole.WRITABLE),
+      accountMetaWithDefault(accounts.memory, AccountRole.WRITABLE),
       ...(remainingAccounts ?? []),
     ],
     data: getMemoryCloseInstructionDataEncoder().encode(args),
@@ -290,7 +282,7 @@ export function getMemoryCloseInstructionRaw<
     TProgram,
     TAccountProgramId,
     TAccountPayer,
-    TAccountMemoryAccount,
+    TAccountMemory,
     TRemainingAccounts
   >;
 }
@@ -306,7 +298,7 @@ export type ParsedMemoryCloseInstruction<
     /** Payer account */
     payer: TAccountMetas[1];
     /** Memory account */
-    memoryAccount: TAccountMetas[2];
+    memory: TAccountMetas[2];
   };
   data: MemoryCloseInstructionData;
 };
@@ -334,7 +326,7 @@ export function parseMemoryCloseInstruction<
     accounts: {
       programId: getNextAccount(),
       payer: getNextAccount(),
-      memoryAccount: getNextAccount(),
+      memory: getNextAccount(),
     },
     data: getMemoryCloseInstructionDataDecoder().decode(instruction.data),
   };

--- a/clients/js/src/generated/instructions/memoryWrite.ts
+++ b/clients/js/src/generated/instructions/memoryWrite.ts
@@ -52,7 +52,7 @@ export type MemoryWriteInstruction<
     | string
     | IAccountMeta<string> = '11111111111111111111111111111111',
   TAccountPayer extends string | IAccountMeta<string> = string,
-  TAccountMemoryAccount extends string | IAccountMeta<string> = string,
+  TAccountMemory extends string | IAccountMeta<string> = string,
   TAccountSourceAccount extends string | IAccountMeta<string> = string,
   TRemainingAccounts extends Array<IAccountMeta<string>> = []
 > = IInstruction<TProgram> &
@@ -68,9 +68,9 @@ export type MemoryWriteInstruction<
       TAccountPayer extends string
         ? ReadonlySignerAccount<TAccountPayer>
         : TAccountPayer,
-      TAccountMemoryAccount extends string
-        ? WritableAccount<TAccountMemoryAccount>
-        : TAccountMemoryAccount,
+      TAccountMemory extends string
+        ? WritableAccount<TAccountMemory>
+        : TAccountMemory,
       TAccountSourceAccount extends string
         ? ReadonlyAccount<TAccountSourceAccount>
         : TAccountSourceAccount,
@@ -87,7 +87,7 @@ export type MemoryWriteInstructionWithSigners<
     | string
     | IAccountMeta<string> = '11111111111111111111111111111111',
   TAccountPayer extends string | IAccountMeta<string> = string,
-  TAccountMemoryAccount extends string | IAccountMeta<string> = string,
+  TAccountMemory extends string | IAccountMeta<string> = string,
   TAccountSourceAccount extends string | IAccountMeta<string> = string,
   TRemainingAccounts extends Array<IAccountMeta<string>> = []
 > = IInstruction<TProgram> &
@@ -104,9 +104,9 @@ export type MemoryWriteInstructionWithSigners<
         ? ReadonlySignerAccount<TAccountPayer> &
             IAccountSignerMeta<TAccountPayer>
         : TAccountPayer,
-      TAccountMemoryAccount extends string
-        ? WritableAccount<TAccountMemoryAccount>
-        : TAccountMemoryAccount,
+      TAccountMemory extends string
+        ? WritableAccount<TAccountMemory>
+        : TAccountMemory,
       TAccountSourceAccount extends string
         ? ReadonlyAccount<TAccountSourceAccount>
         : TAccountSourceAccount,
@@ -116,16 +116,16 @@ export type MemoryWriteInstructionWithSigners<
 
 export type MemoryWriteInstructionData = {
   discriminator: number;
-  memoryIndex: number;
-  memoryAccountBump: number;
-  memoryOffset: number;
+  memoryId: number;
+  memoryBump: number;
+  writeOffset: number;
   writeType: WriteType;
 };
 
 export type MemoryWriteInstructionDataArgs = {
-  memoryIndex: number;
-  memoryAccountBump: number;
-  memoryOffset: number;
+  memoryId: number;
+  memoryBump: number;
+  writeOffset: number;
   writeType: WriteTypeArgs;
 };
 
@@ -133,9 +133,9 @@ export function getMemoryWriteInstructionDataEncoder(): Encoder<MemoryWriteInstr
   return mapEncoder(
     getStructEncoder([
       ['discriminator', getU8Encoder()],
-      ['memoryIndex', getU8Encoder()],
-      ['memoryAccountBump', getU8Encoder()],
-      ['memoryOffset', getU16Encoder()],
+      ['memoryId', getU8Encoder()],
+      ['memoryBump', getU8Encoder()],
+      ['writeOffset', getU16Encoder()],
       ['writeType', getWriteTypeEncoder()],
     ]),
     (value) => ({ ...value, discriminator: 0 })
@@ -145,9 +145,9 @@ export function getMemoryWriteInstructionDataEncoder(): Encoder<MemoryWriteInstr
 export function getMemoryWriteInstructionDataDecoder(): Decoder<MemoryWriteInstructionData> {
   return getStructDecoder([
     ['discriminator', getU8Decoder()],
-    ['memoryIndex', getU8Decoder()],
-    ['memoryAccountBump', getU8Decoder()],
-    ['memoryOffset', getU16Decoder()],
+    ['memoryId', getU8Decoder()],
+    ['memoryBump', getU8Decoder()],
+    ['writeOffset', getU16Decoder()],
     ['writeType', getWriteTypeDecoder()],
   ]);
 }
@@ -166,7 +166,7 @@ export type MemoryWriteInput<
   TAccountProgramId extends string,
   TAccountSystemProgram extends string,
   TAccountPayer extends string,
-  TAccountMemoryAccount extends string,
+  TAccountMemory extends string,
   TAccountSourceAccount extends string
 > = {
   /** Lighthouse program */
@@ -176,12 +176,12 @@ export type MemoryWriteInput<
   /** Payer account */
   payer: Address<TAccountPayer>;
   /** Memory account */
-  memoryAccount: Address<TAccountMemoryAccount>;
+  memory: Address<TAccountMemory>;
   /** System program */
   sourceAccount: Address<TAccountSourceAccount>;
-  memoryIndex: MemoryWriteInstructionDataArgs['memoryIndex'];
-  memoryAccountBump: MemoryWriteInstructionDataArgs['memoryAccountBump'];
-  memoryOffset: MemoryWriteInstructionDataArgs['memoryOffset'];
+  memoryId: MemoryWriteInstructionDataArgs['memoryId'];
+  memoryBump: MemoryWriteInstructionDataArgs['memoryBump'];
+  writeOffset: MemoryWriteInstructionDataArgs['writeOffset'];
   writeType: MemoryWriteInstructionDataArgs['writeType'];
 };
 
@@ -189,7 +189,7 @@ export type MemoryWriteInputWithSigners<
   TAccountProgramId extends string,
   TAccountSystemProgram extends string,
   TAccountPayer extends string,
-  TAccountMemoryAccount extends string,
+  TAccountMemory extends string,
   TAccountSourceAccount extends string
 > = {
   /** Lighthouse program */
@@ -199,12 +199,12 @@ export type MemoryWriteInputWithSigners<
   /** Payer account */
   payer: TransactionSigner<TAccountPayer>;
   /** Memory account */
-  memoryAccount: Address<TAccountMemoryAccount>;
+  memory: Address<TAccountMemory>;
   /** System program */
   sourceAccount: Address<TAccountSourceAccount>;
-  memoryIndex: MemoryWriteInstructionDataArgs['memoryIndex'];
-  memoryAccountBump: MemoryWriteInstructionDataArgs['memoryAccountBump'];
-  memoryOffset: MemoryWriteInstructionDataArgs['memoryOffset'];
+  memoryId: MemoryWriteInstructionDataArgs['memoryId'];
+  memoryBump: MemoryWriteInstructionDataArgs['memoryBump'];
+  writeOffset: MemoryWriteInstructionDataArgs['writeOffset'];
   writeType: MemoryWriteInstructionDataArgs['writeType'];
 };
 
@@ -212,7 +212,7 @@ export function getMemoryWriteInstruction<
   TAccountProgramId extends string,
   TAccountSystemProgram extends string,
   TAccountPayer extends string,
-  TAccountMemoryAccount extends string,
+  TAccountMemory extends string,
   TAccountSourceAccount extends string,
   TProgram extends string = 'L1TEVtgA75k273wWz1s6XMmDhQY5i3MwcvKb4VbZzfK'
 >(
@@ -220,7 +220,7 @@ export function getMemoryWriteInstruction<
     TAccountProgramId,
     TAccountSystemProgram,
     TAccountPayer,
-    TAccountMemoryAccount,
+    TAccountMemory,
     TAccountSourceAccount
   >
 ): MemoryWriteInstructionWithSigners<
@@ -228,14 +228,14 @@ export function getMemoryWriteInstruction<
   TAccountProgramId,
   TAccountSystemProgram,
   TAccountPayer,
-  TAccountMemoryAccount,
+  TAccountMemory,
   TAccountSourceAccount
 >;
 export function getMemoryWriteInstruction<
   TAccountProgramId extends string,
   TAccountSystemProgram extends string,
   TAccountPayer extends string,
-  TAccountMemoryAccount extends string,
+  TAccountMemory extends string,
   TAccountSourceAccount extends string,
   TProgram extends string = 'L1TEVtgA75k273wWz1s6XMmDhQY5i3MwcvKb4VbZzfK'
 >(
@@ -243,7 +243,7 @@ export function getMemoryWriteInstruction<
     TAccountProgramId,
     TAccountSystemProgram,
     TAccountPayer,
-    TAccountMemoryAccount,
+    TAccountMemory,
     TAccountSourceAccount
   >
 ): MemoryWriteInstruction<
@@ -251,14 +251,14 @@ export function getMemoryWriteInstruction<
   TAccountProgramId,
   TAccountSystemProgram,
   TAccountPayer,
-  TAccountMemoryAccount,
+  TAccountMemory,
   TAccountSourceAccount
 >;
 export function getMemoryWriteInstruction<
   TAccountProgramId extends string,
   TAccountSystemProgram extends string,
   TAccountPayer extends string,
-  TAccountMemoryAccount extends string,
+  TAccountMemory extends string,
   TAccountSourceAccount extends string,
   TProgram extends string = 'L1TEVtgA75k273wWz1s6XMmDhQY5i3MwcvKb4VbZzfK'
 >(
@@ -266,7 +266,7 @@ export function getMemoryWriteInstruction<
     TAccountProgramId,
     TAccountSystemProgram,
     TAccountPayer,
-    TAccountMemoryAccount,
+    TAccountMemory,
     TAccountSourceAccount
   >
 ): IInstruction {
@@ -281,7 +281,7 @@ export function getMemoryWriteInstruction<
       TAccountProgramId,
       TAccountSystemProgram,
       TAccountPayer,
-      TAccountMemoryAccount,
+      TAccountMemory,
       TAccountSourceAccount
     >
   >[0];
@@ -289,7 +289,7 @@ export function getMemoryWriteInstruction<
     programId: { value: input.programId ?? null, isWritable: false },
     systemProgram: { value: input.systemProgram ?? null, isWritable: false },
     payer: { value: input.payer ?? null, isWritable: false },
-    memoryAccount: { value: input.memoryAccount ?? null, isWritable: true },
+    memory: { value: input.memory ?? null, isWritable: true },
     sourceAccount: { value: input.sourceAccount ?? null, isWritable: false },
   };
 
@@ -331,7 +331,7 @@ export function getMemoryWriteInstructionRaw<
     | string
     | IAccountMeta<string> = '11111111111111111111111111111111',
   TAccountPayer extends string | IAccountMeta<string> = string,
-  TAccountMemoryAccount extends string | IAccountMeta<string> = string,
+  TAccountMemory extends string | IAccountMeta<string> = string,
   TAccountSourceAccount extends string | IAccountMeta<string> = string,
   TRemainingAccounts extends Array<IAccountMeta<string>> = []
 >(
@@ -345,9 +345,9 @@ export function getMemoryWriteInstructionRaw<
     payer: TAccountPayer extends string
       ? Address<TAccountPayer>
       : TAccountPayer;
-    memoryAccount: TAccountMemoryAccount extends string
-      ? Address<TAccountMemoryAccount>
-      : TAccountMemoryAccount;
+    memory: TAccountMemory extends string
+      ? Address<TAccountMemory>
+      : TAccountMemory;
     sourceAccount: TAccountSourceAccount extends string
       ? Address<TAccountSourceAccount>
       : TAccountSourceAccount;
@@ -372,7 +372,7 @@ export function getMemoryWriteInstructionRaw<
         AccountRole.READONLY
       ),
       accountMetaWithDefault(accounts.payer, AccountRole.READONLY_SIGNER),
-      accountMetaWithDefault(accounts.memoryAccount, AccountRole.WRITABLE),
+      accountMetaWithDefault(accounts.memory, AccountRole.WRITABLE),
       accountMetaWithDefault(accounts.sourceAccount, AccountRole.READONLY),
       ...(remainingAccounts ?? []),
     ],
@@ -383,7 +383,7 @@ export function getMemoryWriteInstructionRaw<
     TAccountProgramId,
     TAccountSystemProgram,
     TAccountPayer,
-    TAccountMemoryAccount,
+    TAccountMemory,
     TAccountSourceAccount,
     TRemainingAccounts
   >;
@@ -402,7 +402,7 @@ export type ParsedMemoryWriteInstruction<
     /** Payer account */
     payer: TAccountMetas[2];
     /** Memory account */
-    memoryAccount: TAccountMetas[3];
+    memory: TAccountMetas[3];
     /** System program */
     sourceAccount: TAccountMetas[4];
   };
@@ -433,7 +433,7 @@ export function parseMemoryWriteInstruction<
       programId: getNextAccount(),
       systemProgram: getNextAccount(),
       payer: getNextAccount(),
-      memoryAccount: getNextAccount(),
+      memory: getNextAccount(),
       sourceAccount: getNextAccount(),
     },
     data: getMemoryWriteInstructionDataDecoder().decode(instruction.data),

--- a/clients/js/src/generated/pdas/index.ts
+++ b/clients/js/src/generated/pdas/index.ts
@@ -6,4 +6,4 @@
  * @see https://github.com/metaplex-foundation/kinobi
  */
 
-export * from './memoryAccount';
+export * from './memory';

--- a/clients/js/src/generated/pdas/memory.ts
+++ b/clients/js/src/generated/pdas/memory.ts
@@ -14,14 +14,14 @@ import {
 } from '@solana/addresses';
 import { getStringEncoder, getU8Encoder } from '@solana/codecs';
 
-export type MemoryAccountSeeds = {
+export type MemorySeeds = {
   payer: Address;
 
-  memoryIndex: number;
+  memoryId: number;
 };
 
-export async function findMemoryAccountPda(
-  seeds: MemoryAccountSeeds,
+export async function findMemoryPda(
+  seeds: MemorySeeds,
   config: { programAddress?: Address | undefined } = {}
 ): Promise<ProgramDerivedAddress> {
   const {
@@ -32,7 +32,7 @@ export async function findMemoryAccountPda(
     seeds: [
       getStringEncoder({ size: 'variable' }).encode('memory'),
       getAddressEncoder().encode(seeds.payer),
-      getU8Encoder().encode(seeds.memoryIndex),
+      getU8Encoder().encode(seeds.memoryId),
     ],
   });
 }

--- a/clients/rust/src/generated/instructions/memory_close.rs
+++ b/clients/rust/src/generated/instructions/memory_close.rs
@@ -15,7 +15,7 @@ pub struct MemoryClose {
     /// Payer account
     pub payer: solana_program::pubkey::Pubkey,
     /// Memory account
-    pub memory_account: solana_program::pubkey::Pubkey,
+    pub memory: solana_program::pubkey::Pubkey,
 }
 
 impl MemoryClose {
@@ -40,7 +40,7 @@ impl MemoryClose {
             self.payer, true,
         ));
         accounts.push(solana_program::instruction::AccountMeta::new(
-            self.memory_account,
+            self.memory,
             false,
         ));
         accounts.extend_from_slice(remaining_accounts);
@@ -70,8 +70,8 @@ impl MemoryCloseInstructionData {
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct MemoryCloseInstructionArgs {
-    pub memory_index: u8,
-    pub memory_account_bump: u8,
+    pub memory_id: u8,
+    pub memory_bump: u8,
 }
 
 /// Instruction builder for `MemoryClose`.
@@ -80,14 +80,14 @@ pub struct MemoryCloseInstructionArgs {
 ///
 ///   0. `[]` program_id
 ///   1. `[signer]` payer
-///   2. `[writable]` memory_account
+///   2. `[writable]` memory
 #[derive(Default)]
 pub struct MemoryCloseBuilder {
     program_id: Option<solana_program::pubkey::Pubkey>,
     payer: Option<solana_program::pubkey::Pubkey>,
-    memory_account: Option<solana_program::pubkey::Pubkey>,
-    memory_index: Option<u8>,
-    memory_account_bump: Option<u8>,
+    memory: Option<solana_program::pubkey::Pubkey>,
+    memory_id: Option<u8>,
+    memory_bump: Option<u8>,
     __remaining_accounts: Vec<solana_program::instruction::AccountMeta>,
 }
 
@@ -109,18 +109,18 @@ impl MemoryCloseBuilder {
     }
     /// Memory account
     #[inline(always)]
-    pub fn memory_account(&mut self, memory_account: solana_program::pubkey::Pubkey) -> &mut Self {
-        self.memory_account = Some(memory_account);
+    pub fn memory(&mut self, memory: solana_program::pubkey::Pubkey) -> &mut Self {
+        self.memory = Some(memory);
         self
     }
     #[inline(always)]
-    pub fn memory_index(&mut self, memory_index: u8) -> &mut Self {
-        self.memory_index = Some(memory_index);
+    pub fn memory_id(&mut self, memory_id: u8) -> &mut Self {
+        self.memory_id = Some(memory_id);
         self
     }
     #[inline(always)]
-    pub fn memory_account_bump(&mut self, memory_account_bump: u8) -> &mut Self {
-        self.memory_account_bump = Some(memory_account_bump);
+    pub fn memory_bump(&mut self, memory_bump: u8) -> &mut Self {
+        self.memory_bump = Some(memory_bump);
         self
     }
     /// Add an aditional account to the instruction.
@@ -146,14 +146,11 @@ impl MemoryCloseBuilder {
         let accounts = MemoryClose {
             program_id: self.program_id.expect("program_id is not set"),
             payer: self.payer.expect("payer is not set"),
-            memory_account: self.memory_account.expect("memory_account is not set"),
+            memory: self.memory.expect("memory is not set"),
         };
         let args = MemoryCloseInstructionArgs {
-            memory_index: self.memory_index.clone().expect("memory_index is not set"),
-            memory_account_bump: self
-                .memory_account_bump
-                .clone()
-                .expect("memory_account_bump is not set"),
+            memory_id: self.memory_id.clone().expect("memory_id is not set"),
+            memory_bump: self.memory_bump.clone().expect("memory_bump is not set"),
         };
 
         accounts.instruction_with_remaining_accounts(args, &self.__remaining_accounts)
@@ -167,7 +164,7 @@ pub struct MemoryCloseCpiAccounts<'a, 'b> {
     /// Payer account
     pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// Memory account
-    pub memory_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub memory: &'b solana_program::account_info::AccountInfo<'a>,
 }
 
 /// `memory_close` CPI instruction.
@@ -179,7 +176,7 @@ pub struct MemoryCloseCpi<'a, 'b> {
     /// Payer account
     pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// Memory account
-    pub memory_account: &'b solana_program::account_info::AccountInfo<'a>,
+    pub memory: &'b solana_program::account_info::AccountInfo<'a>,
     /// The arguments for the instruction.
     pub __args: MemoryCloseInstructionArgs,
 }
@@ -194,7 +191,7 @@ impl<'a, 'b> MemoryCloseCpi<'a, 'b> {
             __program: program,
             program_id: accounts.program_id,
             payer: accounts.payer,
-            memory_account: accounts.memory_account,
+            memory: accounts.memory,
             __args: args,
         }
     }
@@ -241,7 +238,7 @@ impl<'a, 'b> MemoryCloseCpi<'a, 'b> {
             true,
         ));
         accounts.push(solana_program::instruction::AccountMeta::new(
-            *self.memory_account.key,
+            *self.memory.key,
             false,
         ));
         remaining_accounts.iter().for_each(|remaining_account| {
@@ -264,7 +261,7 @@ impl<'a, 'b> MemoryCloseCpi<'a, 'b> {
         account_infos.push(self.__program.clone());
         account_infos.push(self.program_id.clone());
         account_infos.push(self.payer.clone());
-        account_infos.push(self.memory_account.clone());
+        account_infos.push(self.memory.clone());
         remaining_accounts
             .iter()
             .for_each(|remaining_account| account_infos.push(remaining_account.0.clone()));
@@ -283,7 +280,7 @@ impl<'a, 'b> MemoryCloseCpi<'a, 'b> {
 ///
 ///   0. `[]` program_id
 ///   1. `[signer]` payer
-///   2. `[writable]` memory_account
+///   2. `[writable]` memory
 pub struct MemoryCloseCpiBuilder<'a, 'b> {
     instruction: Box<MemoryCloseCpiBuilderInstruction<'a, 'b>>,
 }
@@ -294,9 +291,9 @@ impl<'a, 'b> MemoryCloseCpiBuilder<'a, 'b> {
             __program: program,
             program_id: None,
             payer: None,
-            memory_account: None,
-            memory_index: None,
-            memory_account_bump: None,
+            memory: None,
+            memory_id: None,
+            memory_bump: None,
             __remaining_accounts: Vec::new(),
         });
         Self { instruction }
@@ -318,21 +315,21 @@ impl<'a, 'b> MemoryCloseCpiBuilder<'a, 'b> {
     }
     /// Memory account
     #[inline(always)]
-    pub fn memory_account(
+    pub fn memory(
         &mut self,
-        memory_account: &'b solana_program::account_info::AccountInfo<'a>,
+        memory: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
-        self.instruction.memory_account = Some(memory_account);
+        self.instruction.memory = Some(memory);
         self
     }
     #[inline(always)]
-    pub fn memory_index(&mut self, memory_index: u8) -> &mut Self {
-        self.instruction.memory_index = Some(memory_index);
+    pub fn memory_id(&mut self, memory_id: u8) -> &mut Self {
+        self.instruction.memory_id = Some(memory_id);
         self
     }
     #[inline(always)]
-    pub fn memory_account_bump(&mut self, memory_account_bump: u8) -> &mut Self {
-        self.instruction.memory_account_bump = Some(memory_account_bump);
+    pub fn memory_bump(&mut self, memory_bump: u8) -> &mut Self {
+        self.instruction.memory_bump = Some(memory_bump);
         self
     }
     /// Add an additional account to the instruction.
@@ -377,16 +374,16 @@ impl<'a, 'b> MemoryCloseCpiBuilder<'a, 'b> {
         signers_seeds: &[&[&[u8]]],
     ) -> solana_program::entrypoint::ProgramResult {
         let args = MemoryCloseInstructionArgs {
-            memory_index: self
+            memory_id: self
                 .instruction
-                .memory_index
+                .memory_id
                 .clone()
-                .expect("memory_index is not set"),
-            memory_account_bump: self
+                .expect("memory_id is not set"),
+            memory_bump: self
                 .instruction
-                .memory_account_bump
+                .memory_bump
                 .clone()
-                .expect("memory_account_bump is not set"),
+                .expect("memory_bump is not set"),
         };
         let instruction = MemoryCloseCpi {
             __program: self.instruction.__program,
@@ -395,10 +392,7 @@ impl<'a, 'b> MemoryCloseCpiBuilder<'a, 'b> {
 
             payer: self.instruction.payer.expect("payer is not set"),
 
-            memory_account: self
-                .instruction
-                .memory_account
-                .expect("memory_account is not set"),
+            memory: self.instruction.memory.expect("memory is not set"),
             __args: args,
         };
         instruction.invoke_signed_with_remaining_accounts(
@@ -412,9 +406,9 @@ struct MemoryCloseCpiBuilderInstruction<'a, 'b> {
     __program: &'b solana_program::account_info::AccountInfo<'a>,
     program_id: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    memory_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    memory_index: Option<u8>,
-    memory_account_bump: Option<u8>,
+    memory: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    memory_id: Option<u8>,
+    memory_bump: Option<u8>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
     __remaining_accounts: Vec<(
         &'b solana_program::account_info::AccountInfo<'a>,

--- a/clients/rust/src/lib.rs
+++ b/clients/rust/src/lib.rs
@@ -24,9 +24,9 @@ pub mod errors {
     pub use crate::generated::errors::*;
 }
 
-pub fn get_memory(user: Pubkey, memory_id: u8) -> (solana_program::pubkey::Pubkey, u8) {
+pub fn find_memory_pda(payer: Pubkey, memory_id: u8) -> (solana_program::pubkey::Pubkey, u8) {
     solana_program::pubkey::Pubkey::find_program_address(
-        &["memory".to_string().as_ref(), user.as_ref(), &[memory_id]],
+        &["memory".to_string().as_ref(), payer.as_ref(), &[memory_id]],
         &crate::ID,
     )
 }

--- a/clients/rust/src/lib.rs
+++ b/clients/rust/src/lib.rs
@@ -24,13 +24,9 @@ pub mod errors {
     pub use crate::generated::errors::*;
 }
 
-pub fn get_memory_account(user: Pubkey, memory_index: u8) -> (solana_program::pubkey::Pubkey, u8) {
+pub fn get_memory(user: Pubkey, memory_id: u8) -> (solana_program::pubkey::Pubkey, u8) {
     solana_program::pubkey::Pubkey::find_program_address(
-        &[
-            "memory".to_string().as_ref(),
-            user.as_ref(),
-            &[memory_index],
-        ],
+        &["memory".to_string().as_ref(), user.as_ref(), &[memory_id]],
         &crate::ID,
     )
 }

--- a/configs/kinobi.cjs
+++ b/configs/kinobi.cjs
@@ -18,15 +18,18 @@ const kinobi = k.createFromIdls([path.join(programDir, 'lighthouse.json')]);
 kinobi.update(
   k.addPdasVisitor({
     lighthouse: [
-      k.pdaNode('memory_account', [
+      k.pdaNode('memory', [
         k.constantPdaSeedNodeFromString('memory'),
         k.variablePdaSeedNode('payer', k.publicKeyTypeNode()),
-        k.variablePdaSeedNode('memory_index', k.numberTypeNode('u8')),
+        k.variablePdaSeedNode('memory_id', k.numberTypeNode('u8')),
       ]),
     ],
   })
 );
 
+//
+// How to set a default value for an account in an instruction.
+//
 // kinobi.update(
 //   k.updateInstructionsVisitor({
 //     memoryWrite: {
@@ -35,19 +38,25 @@ kinobi.update(
 //           defaultValue: k.publicKeyValueNode('<pubkey>'),
 //         },
 //         memoryAccount: {
-//           defaultValue: k.pdaValueNode('memory_account'),
+//           defaultValue: k.pdaValueNode('memory'),
 //         },
 //       },
 //     },
 //   })
 // );
 
+//
+// How to long the kinobi tree
+//
 // kinobi.accept(k.consoleLogVisitor(k.getDebugStringVisitor({ indent: true })));
 
+//
+// Setting a default value for an instruction arg.
+//
 // kinobi.update(
 //   k.setStructDefaultValuesVisitor({
 //     memoryWrite: {
-//       memory_index: k.numberValueNode(0),
+//       memory_id: k.numberValueNode(0),
 //     },
 //   })
 // );

--- a/programs/lighthouse/program/lighthouse.json
+++ b/programs/lighthouse/program/lighthouse.json
@@ -30,7 +30,7 @@
           ]
         },
         {
-          "name": "memoryAccount",
+          "name": "memory",
           "isMut": true,
           "isSigner": false,
           "docs": [
@@ -48,15 +48,15 @@
       ],
       "args": [
         {
-          "name": "memoryIndex",
+          "name": "memoryId",
           "type": "u8"
         },
         {
-          "name": "memoryAccountBump",
+          "name": "memoryBump",
           "type": "u8"
         },
         {
-          "name": "memoryOffset",
+          "name": "writeOffset",
           "type": "u16"
         },
         {
@@ -91,7 +91,7 @@
           ]
         },
         {
-          "name": "memoryAccount",
+          "name": "memory",
           "isMut": true,
           "isSigner": false,
           "docs": [
@@ -101,11 +101,11 @@
       ],
       "args": [
         {
-          "name": "memoryIndex",
+          "name": "memoryId",
           "type": "u8"
         },
         {
-          "name": "memoryAccountBump",
+          "name": "memoryBump",
           "type": "u8"
         }
       ],

--- a/programs/lighthouse/program/src/instruction.rs
+++ b/programs/lighthouse/program/src/instruction.rs
@@ -15,19 +15,19 @@ pub(crate) enum LighthouseInstruction {
     #[account(0, name = "program_id", desc = "Lighthouse program")]
     #[account(1, name = "system_program", desc = "System program")]
     #[account(2, name = "payer", desc = "Payer account", signer)]
-    #[account(3, name = "memory_account", desc = "Memory account", writable)]
+    #[account(3, name = "memory", desc = "Memory account", writable)]
     #[account(4, name = "source_account", desc = "System program")]
     MemoryWrite { 
-        memory_index: u8,
-        memory_account_bump: u8,
-        memory_offset: u16,
+        memory_id: u8,
+        memory_bump: u8,
+        write_offset: u16,
         write_type: WriteType,
     },
 
     #[account(0, name = "program_id", desc = "Lighthouse program")]
     #[account(1, name = "payer", desc = "Payer account", signer)]
-    #[account(2, name = "memory_account", desc = "Memory account", writable)]
-    MemoryClose { memory_index: u8, memory_account_bump: u8 },
+    #[account(2, name = "memory", desc = "Memory account", writable)]
+    MemoryClose { memory_id: u8, memory_bump: u8 },
 
     #[account(0, name = "target_account", desc = "Target account to be asserted")]
     AssertAccountData { log_level: LogLevel, assertion: AccountDataAssertion },

--- a/programs/lighthouse/program/src/instruction.rs
+++ b/programs/lighthouse/program/src/instruction.rs
@@ -16,7 +16,7 @@ pub(crate) enum LighthouseInstruction {
     #[account(1, name = "system_program", desc = "System program")]
     #[account(2, name = "payer", desc = "Payer account", signer)]
     #[account(3, name = "memory", desc = "Memory account", writable)]
-    #[account(4, name = "source_account", desc = "System program")]
+    #[account(4, name = "source_account", desc = "Account to be written to memory")]
     MemoryWrite { 
         memory_id: u8,
         memory_bump: u8,

--- a/programs/lighthouse/program/src/lib.rs
+++ b/programs/lighthouse/program/src/lib.rs
@@ -40,29 +40,26 @@ pub mod lighthouse {
 
         match instruction {
             LighthouseInstruction::MemoryWrite {
-                memory_index,
-                memory_account_bump,
-                memory_offset,
+                memory_id,
+                memory_bump,
+                write_offset,
                 write_type,
             } => {
                 let context = MemoryWriteContext::load(
                     &mut accounts.iter(),
-                    memory_index,
-                    memory_offset,
-                    memory_account_bump,
+                    memory_id,
+                    write_offset,
+                    memory_bump,
                     &write_type,
                 )?;
-                processor::memory_write(&context, memory_offset, &write_type)?;
+                processor::memory_write(&context, write_offset, &write_type)?;
             }
             LighthouseInstruction::MemoryClose {
-                memory_index,
-                memory_account_bump,
+                memory_id,
+                memory_bump,
             } => {
-                let context = MemoryCloseContext::load(
-                    &mut accounts.iter(),
-                    memory_index,
-                    memory_account_bump,
-                )?;
+                let context =
+                    MemoryCloseContext::load(&mut accounts.iter(), memory_id, memory_bump)?;
                 processor::memory_close(&context)?;
             }
             LighthouseInstruction::AssertAccountData {

--- a/programs/lighthouse/program/src/processor/memory_close.rs
+++ b/programs/lighthouse/program/src/processor/memory_close.rs
@@ -1,7 +1,7 @@
 use crate::utils::{close, Result};
 use crate::validation::{
-    AccountValidation, CheckedAccount, DerivedAddress, LighthouseProgram, MemoryAccount,
-    MemoryAccountSeeds, Program, Signer,
+    AccountValidation, CheckedAccount, DerivedAddress, LighthouseProgram, Memory, MemorySeeds,
+    Program, Signer,
 };
 use solana_program::account_info::{next_account_info, AccountInfo};
 use std::slice::Iter;
@@ -10,25 +10,25 @@ use std::slice::Iter;
 pub(crate) struct MemoryCloseContext<'a, 'info> {
     pub lighthouse_program: Program<'a, 'info, LighthouseProgram>,
     pub payer: Signer<'a, 'info>,
-    pub memory_account: MemoryAccount<'a, 'info>,
+    pub memory: Memory<'a, 'info>,
 }
 
 impl<'a, 'info> MemoryCloseContext<'a, 'info> {
     pub(crate) fn load(
         account_iter: &mut Iter<'a, AccountInfo<'info>>,
-        memory_index: u8,
-        memory_account_bump: u8,
+        memory_id: u8,
+        memory_bump: u8,
     ) -> Result<Self> {
         let lighthouse_program = Program::new_checked(next_account_info(account_iter)?, None)?;
         let payer = Signer::new_checked(next_account_info(account_iter)?, None)?;
 
-        let seeds = &MemoryAccount::get_seeds(MemoryAccountSeeds {
+        let seeds = &Memory::get_seeds(MemorySeeds {
             payer: payer.key,
-            memory_index,
-            bump: Some(memory_account_bump),
+            memory_id,
+            bump: Some(memory_bump),
         });
 
-        let memory_account = MemoryAccount::new_checked(
+        let memory = Memory::new_checked(
             next_account_info(account_iter)?,
             Some(&vec![
                 AccountValidation::IsWritable,
@@ -44,14 +44,14 @@ impl<'a, 'info> MemoryCloseContext<'a, 'info> {
         Ok(Self {
             lighthouse_program,
             payer,
-            memory_account,
+            memory,
         })
     }
 }
 
 pub(crate) fn memory_close(context: &MemoryCloseContext) -> Result<()> {
     close(
-        context.memory_account.info_as_owned(),
+        context.memory.info_as_owned(),
         context.payer.info_as_owned(),
     )?;
 

--- a/programs/lighthouse/program/src/validation/memory.rs
+++ b/programs/lighthouse/program/src/validation/memory.rs
@@ -2,37 +2,34 @@ use super::{AccountValidation, CheckedAccount, DerivedAddress};
 use solana_program::{account_info::AccountInfo, pubkey::Pubkey};
 
 #[derive(Clone)]
-pub struct MemoryAccount<'a, 'info> {
+pub struct Memory<'a, 'info> {
     info: &'a AccountInfo<'info>,
 }
 
-pub struct MemoryAccountSeeds<'a> {
+pub struct MemorySeeds<'a> {
     pub payer: &'a Pubkey,
-    pub memory_index: u8,
+    pub memory_id: u8,
     pub bump: Option<u8>,
 }
 
-impl<'a, 'info> DerivedAddress<MemoryAccountSeeds<'a>> for MemoryAccount<'a, 'info> {
-    fn get_seeds(seeds: MemoryAccountSeeds<'a>) -> Vec<Vec<u8>> {
-        let MemoryAccountSeeds {
+impl<'a, 'info> DerivedAddress<MemorySeeds<'a>> for Memory<'a, 'info> {
+    fn get_seeds(seeds: MemorySeeds<'a>) -> Vec<Vec<u8>> {
+        let MemorySeeds {
             payer,
-            memory_index,
+            memory_id,
             bump,
         } = seeds;
 
         vec![
             b"memory".to_vec(),
             payer.to_bytes().to_vec(),
-            if let Some(bump) = bump {
-                vec![memory_index, bump]
-            } else {
-                vec![memory_index]
-            },
+            vec![memory_id],
+            bump.map_or_else(std::vec::Vec::new, |b| vec![b]),
         ]
     }
 }
 
-impl<'a, 'info> CheckedAccount<'a, 'info> for MemoryAccount<'a, 'info> {
+impl<'a, 'info> CheckedAccount<'a, 'info> for Memory<'a, 'info> {
     fn info(&self) -> &'a AccountInfo<'info> {
         self.info
     }

--- a/programs/lighthouse/program/src/validation/mod.rs
+++ b/programs/lighthouse/program/src/validation/mod.rs
@@ -1,11 +1,11 @@
 pub mod account;
 pub mod defs;
-pub mod memory_account;
+pub mod memory;
 pub mod program;
 pub mod signer;
 
 pub(crate) use account::*;
 pub(crate) use defs::*;
-pub(crate) use memory_account::*;
+pub(crate) use memory::*;
 pub(crate) use program::*;
 pub(crate) use signer::*;

--- a/tests/lighthouse/tests/suites/assert/account_data_delta.rs
+++ b/tests/lighthouse/tests/suites/assert/account_data_delta.rs
@@ -1,6 +1,6 @@
 use crate::utils::context::TestContext;
 use crate::utils::process_transaction_assert_success;
-use crate::utils::{create_user_with_balance, find_memory_account};
+use crate::utils::{create_user_with_balance, find_memory};
 use lighthouse_client::instructions::{AssertAccountDeltaBuilder, MemoryWriteBuilder};
 use lighthouse_client::types::{
     AccountDeltaAssertion, AccountInfoDeltaAssertion, AccountInfoField, IntegerOperator, LogLevel,
@@ -22,23 +22,23 @@ async fn slippage_check() {
         .await
         .unwrap();
 
-    let (memory_account, bump) = find_memory_account(user.encodable_pubkey(), 0);
+    let (memory, bump) = find_memory(user.encodable_pubkey(), 0);
 
     let tx = Transaction::new_signed_with_payer(
         &[
             MemoryWriteBuilder::new()
-                .memory_account(memory_account)
+                .memory(memory)
                 .payer(user.encodable_pubkey())
                 .source_account(user.encodable_pubkey())
                 .program_id(lighthouse_client::ID)
                 .write_type(WriteType::AccountInfoField(AccountInfoField::Lamports))
-                .memory_index(0)
-                .memory_offset(0)
-                .memory_account_bump(bump)
+                .memory_id(0)
+                .write_offset(0)
+                .memory_bump(bump)
                 .instruction(),
             AssertAccountDeltaBuilder::new()
                 .log_level(LogLevel::Silent)
-                .account_a(memory_account)
+                .account_a(memory)
                 .account_b(user.encodable_pubkey())
                 .assertion(AccountDeltaAssertion::AccountInfo {
                     a_offset: 0,
@@ -61,14 +61,14 @@ async fn slippage_check() {
     let tx = Transaction::new_signed_with_payer(
         &[
             MemoryWriteBuilder::new()
-                .memory_account(memory_account)
+                .memory(memory)
                 .payer(user.encodable_pubkey())
                 .source_account(user.encodable_pubkey())
                 .program_id(lighthouse_client::ID)
                 .write_type(WriteType::AccountInfoField(AccountInfoField::Lamports))
-                .memory_index(0)
-                .memory_offset(0)
-                .memory_account_bump(bump)
+                .memory_id(0)
+                .write_offset(0)
+                .memory_bump(bump)
                 .instruction(),
             system_instruction::transfer(
                 &user.encodable_pubkey(),
@@ -77,7 +77,7 @@ async fn slippage_check() {
             ),
             AssertAccountDeltaBuilder::new()
                 .log_level(LogLevel::PlaintextMessage)
-                .account_a(memory_account)
+                .account_a(memory)
                 .account_b(user.encodable_pubkey())
                 .assertion(AccountDeltaAssertion::AccountInfo {
                     a_offset: 0,

--- a/tests/lighthouse/tests/suites/assert/account_data_delta.rs
+++ b/tests/lighthouse/tests/suites/assert/account_data_delta.rs
@@ -1,6 +1,7 @@
 use crate::utils::context::TestContext;
+use crate::utils::create_user_with_balance;
 use crate::utils::process_transaction_assert_success;
-use crate::utils::{create_user_with_balance, find_memory};
+use lighthouse_client::find_memory_pda;
 use lighthouse_client::instructions::{AssertAccountDeltaBuilder, MemoryWriteBuilder};
 use lighthouse_client::types::{
     AccountDeltaAssertion, AccountInfoDeltaAssertion, AccountInfoField, IntegerOperator, LogLevel,
@@ -22,7 +23,7 @@ async fn slippage_check() {
         .await
         .unwrap();
 
-    let (memory, bump) = find_memory(user.encodable_pubkey(), 0);
+    let (memory, bump) = find_memory_pda(user.encodable_pubkey(), 0);
 
     let tx = Transaction::new_signed_with_payer(
         &[

--- a/tests/lighthouse/tests/suites/write/simple.rs
+++ b/tests/lighthouse/tests/suites/write/simple.rs
@@ -1,5 +1,6 @@
+use crate::utils::process_transaction_assert_success;
 use crate::utils::{context::TestContext, create_test_account, create_user};
-use crate::utils::{find_memory, process_transaction_assert_success};
+use lighthouse_client::find_memory_pda;
 use lighthouse_client::instructions::{AssertAccountDataBuilder, MemoryWriteBuilder};
 use lighthouse_client::types::{
     ByteSliceOperator, DataValue, DataValueAssertion, EquatableOperator, IntegerOperator, WriteType,
@@ -31,7 +32,7 @@ async fn test_write() {
         .unwrap();
     let account_data_length = account.data.len() as u64;
 
-    let (memory, memory_bump) = find_memory(user.encodable_pubkey(), 0);
+    let (memory, memory_bump) = find_memory_pda(user.encodable_pubkey(), 0);
 
     let tx = Transaction::new_signed_with_payer(
         &[MemoryWriteBuilder::new()
@@ -267,7 +268,7 @@ async fn test_write_u64() {
     let context = &mut TestContext::new().await.unwrap();
     let user = create_user(context).await.unwrap();
 
-    let (memory, memory_bump) = find_memory(user.encodable_pubkey(), 0);
+    let (memory, memory_bump) = find_memory_pda(user.encodable_pubkey(), 0);
 
     // Assert that data was properly written to memory.
     let tx = Transaction::new_signed_with_payer(

--- a/tests/lighthouse/tests/suites/write/simple.rs
+++ b/tests/lighthouse/tests/suites/write/simple.rs
@@ -1,5 +1,5 @@
 use crate::utils::{context::TestContext, create_test_account, create_user};
-use crate::utils::{find_memory_account, process_transaction_assert_success};
+use crate::utils::{find_memory, process_transaction_assert_success};
 use lighthouse_client::instructions::{AssertAccountDataBuilder, MemoryWriteBuilder};
 use lighthouse_client::types::{
     ByteSliceOperator, DataValue, DataValueAssertion, EquatableOperator, IntegerOperator, WriteType,
@@ -31,17 +31,17 @@ async fn test_write() {
         .unwrap();
     let account_data_length = account.data.len() as u64;
 
-    let (memory_account, memory_account_bump) = find_memory_account(user.encodable_pubkey(), 0);
+    let (memory, memory_bump) = find_memory(user.encodable_pubkey(), 0);
 
     let tx = Transaction::new_signed_with_payer(
         &[MemoryWriteBuilder::new()
             .payer(user.encodable_pubkey())
             .source_account(test_account.encodable_pubkey())
-            .memory_account(memory_account)
+            .memory(memory)
             .program_id(lighthouse_client::ID)
-            .memory_index(0)
-            .memory_account_bump(memory_account_bump)
-            .memory_offset(0)
+            .memory_id(0)
+            .memory_bump(memory_bump)
+            .write_offset(0)
             .system_program(system_program::id())
             .write_type(WriteType::AccountData {
                 offset: 8,
@@ -58,15 +58,15 @@ async fn test_write() {
         .await
         .unwrap();
 
-    let memory_account_data = context.get_account(memory_account).await.unwrap().data;
+    let memory_data = context.get_account(memory).await.unwrap().data;
 
-    assert_eq!(test_account_data[8..], memory_account_data[..]);
+    assert_eq!(test_account_data[8..], memory_data[..]);
 
     // Assert that data was properly written to memory.
     let tx = Transaction::new_signed_with_payer(
         &[
             AssertAccountDataBuilder::new()
-                .target_account(memory_account)
+                .target_account(memory)
                 .log_level(lighthouse_client::types::LogLevel::Silent)
                 .assertion(DataValueAssertion::U8 {
                     value: 1,
@@ -75,7 +75,7 @@ async fn test_write() {
                 .offset(0)
                 .instruction(),
             AssertAccountDataBuilder::new()
-                .target_account(memory_account)
+                .target_account(memory)
                 .log_level(lighthouse_client::types::LogLevel::Silent)
                 .assertion(DataValueAssertion::I8 {
                     value: -1,
@@ -84,7 +84,7 @@ async fn test_write() {
                 .offset(1)
                 .instruction(),
             AssertAccountDataBuilder::new()
-                .target_account(memory_account)
+                .target_account(memory)
                 .log_level(lighthouse_client::types::LogLevel::Silent)
                 .assertion(DataValueAssertion::U16 {
                     value: (u8::MAX as u16) + 1,
@@ -93,7 +93,7 @@ async fn test_write() {
                 .offset(2)
                 .instruction(),
             AssertAccountDataBuilder::new()
-                .target_account(memory_account)
+                .target_account(memory)
                 .log_level(lighthouse_client::types::LogLevel::Silent)
                 .assertion(DataValueAssertion::I16 {
                     value: (i8::MIN as i16) - 1,
@@ -102,7 +102,7 @@ async fn test_write() {
                 .offset(4)
                 .instruction(),
             AssertAccountDataBuilder::new()
-                .target_account(memory_account)
+                .target_account(memory)
                 .log_level(lighthouse_client::types::LogLevel::Silent)
                 .assertion(DataValueAssertion::U32 {
                     value: (u16::MAX as u32) + 1,
@@ -111,7 +111,7 @@ async fn test_write() {
                 .offset(6)
                 .instruction(),
             AssertAccountDataBuilder::new()
-                .target_account(memory_account)
+                .target_account(memory)
                 .log_level(lighthouse_client::types::LogLevel::Silent)
                 .assertion(DataValueAssertion::I32 {
                     value: (i16::MIN as i32) - 1,
@@ -120,7 +120,7 @@ async fn test_write() {
                 .offset(10)
                 .instruction(),
             AssertAccountDataBuilder::new()
-                .target_account(memory_account)
+                .target_account(memory)
                 .log_level(lighthouse_client::types::LogLevel::Silent)
                 .assertion(DataValueAssertion::U64 {
                     value: (u32::MAX as u64) + 1,
@@ -129,7 +129,7 @@ async fn test_write() {
                 .offset(14)
                 .instruction(),
             AssertAccountDataBuilder::new()
-                .target_account(memory_account)
+                .target_account(memory)
                 .log_level(lighthouse_client::types::LogLevel::Silent)
                 .assertion(DataValueAssertion::I64 {
                     value: (i32::MIN as i64) - 1,
@@ -138,7 +138,7 @@ async fn test_write() {
                 .offset(22)
                 .instruction(),
             AssertAccountDataBuilder::new()
-                .target_account(memory_account)
+                .target_account(memory)
                 .log_level(lighthouse_client::types::LogLevel::Silent)
                 .assertion(DataValueAssertion::U128 {
                     value: (u64::MAX as u128) + 1,
@@ -147,7 +147,7 @@ async fn test_write() {
                 .offset(30)
                 .instruction(),
             AssertAccountDataBuilder::new()
-                .target_account(memory_account)
+                .target_account(memory)
                 .log_level(lighthouse_client::types::LogLevel::Silent)
                 .assertion(DataValueAssertion::I128 {
                     value: (i64::MIN as i128) - 1,
@@ -156,7 +156,7 @@ async fn test_write() {
                 .offset(46)
                 .instruction(),
             AssertAccountDataBuilder::new()
-                .target_account(memory_account)
+                .target_account(memory)
                 .log_level(lighthouse_client::types::LogLevel::Silent)
                 .assertion(DataValueAssertion::Bytes {
                     value: vec![u8::MAX; 32],
@@ -165,7 +165,7 @@ async fn test_write() {
                 .offset(62)
                 .instruction(),
             AssertAccountDataBuilder::new()
-                .target_account(memory_account)
+                .target_account(memory)
                 .log_level(lighthouse_client::types::LogLevel::Silent)
                 .assertion(DataValueAssertion::Bool {
                     value: true,
@@ -175,7 +175,7 @@ async fn test_write() {
                 .instruction(),
             // False represented as 0
             AssertAccountDataBuilder::new()
-                .target_account(memory_account)
+                .target_account(memory)
                 .log_level(lighthouse_client::types::LogLevel::Silent)
                 .assertion(DataValueAssertion::U8 {
                     value: 0,
@@ -185,7 +185,7 @@ async fn test_write() {
                 .instruction(),
             // Some in Option<u8>
             AssertAccountDataBuilder::new()
-                .target_account(memory_account)
+                .target_account(memory)
                 .log_level(lighthouse_client::types::LogLevel::Silent)
                 .assertion(DataValueAssertion::U8 {
                     value: 1,
@@ -194,7 +194,7 @@ async fn test_write() {
                 .offset(96)
                 .instruction(),
             AssertAccountDataBuilder::new()
-                .target_account(memory_account)
+                .target_account(memory)
                 .log_level(lighthouse_client::types::LogLevel::Silent)
                 .assertion(DataValueAssertion::U8 {
                     value: u8::MAX,
@@ -203,7 +203,7 @@ async fn test_write() {
                 .offset(97)
                 .instruction(),
             AssertAccountDataBuilder::new()
-                .target_account(memory_account)
+                .target_account(memory)
                 .log_level(lighthouse_client::types::LogLevel::Silent)
                 .assertion(DataValueAssertion::U8 {
                     value: 0,
@@ -212,7 +212,7 @@ async fn test_write() {
                 .offset(98)
                 .instruction(),
             AssertAccountDataBuilder::new()
-                .target_account(memory_account)
+                .target_account(memory)
                 .log_level(lighthouse_client::types::LogLevel::Silent)
                 .assertion(DataValueAssertion::Bytes {
                     value: [1, 255, 255].to_vec(),
@@ -221,7 +221,7 @@ async fn test_write() {
                 .offset(99)
                 .instruction(),
             AssertAccountDataBuilder::new()
-                .target_account(memory_account)
+                .target_account(memory)
                 .log_level(lighthouse_client::types::LogLevel::Silent)
                 .assertion(DataValueAssertion::Bytes {
                     value: [0].to_vec(),
@@ -230,7 +230,7 @@ async fn test_write() {
                 .offset(102)
                 .instruction(),
             AssertAccountDataBuilder::new()
-                .target_account(memory_account)
+                .target_account(memory)
                 .log_level(lighthouse_client::types::LogLevel::Silent)
                 .assertion(DataValueAssertion::Pubkey {
                     value: user.encodable_pubkey(),
@@ -239,7 +239,7 @@ async fn test_write() {
                 .offset(103)
                 .instruction(),
             AssertAccountDataBuilder::new()
-                .target_account(memory_account)
+                .target_account(memory)
                 .log_level(lighthouse_client::types::LogLevel::Silent)
                 .assertion(DataValueAssertion::Bytes {
                     value: [32, 0, 0, 0]
@@ -267,7 +267,7 @@ async fn test_write_u64() {
     let context = &mut TestContext::new().await.unwrap();
     let user = create_user(context).await.unwrap();
 
-    let (memory_account, memory_account_bump) = find_memory_account(user.encodable_pubkey(), 0);
+    let (memory, memory_bump) = find_memory(user.encodable_pubkey(), 0);
 
     // Assert that data was properly written to memory.
     let tx = Transaction::new_signed_with_payer(
@@ -275,16 +275,16 @@ async fn test_write_u64() {
             MemoryWriteBuilder::new()
                 .payer(user.encodable_pubkey())
                 .source_account(lighthouse_client::ID)
-                .memory_account(memory_account)
+                .memory(memory)
                 .program_id(lighthouse_client::ID)
-                .memory_account_bump(memory_account_bump)
-                .memory_offset(0)
-                .memory_index(0)
+                .memory_bump(memory_bump)
+                .write_offset(0)
+                .memory_id(0)
                 .system_program(system_program::id())
                 .write_type(WriteType::DataValue(DataValue::U64(u64::MAX / 2)))
                 .instruction(),
             AssertAccountDataBuilder::new()
-                .target_account(memory_account)
+                .target_account(memory)
                 .log_level(lighthouse_client::types::LogLevel::Silent)
                 .assertion(DataValueAssertion::U64 {
                     value: u64::MAX / 2,
@@ -311,10 +311,10 @@ async fn test_write_u64() {
                 .payer(user.encodable_pubkey())
                 .source_account(lighthouse_client::ID)
                 .program_id(lighthouse_client::ID)
-                .memory_account(memory_account)
-                .memory_account_bump(memory_account_bump)
-                .memory_offset(512)
-                .memory_index(0)
+                .memory(memory)
+                .memory_bump(memory_bump)
+                .write_offset(512)
+                .memory_id(0)
                 .system_program(system_program::id())
                 .write_type(WriteType::DataValue(DataValue::U128(u128::MAX)))
                 .instruction(),
@@ -322,17 +322,17 @@ async fn test_write_u64() {
                 .payer(user.encodable_pubkey())
                 .source_account(lighthouse_client::ID)
                 .program_id(lighthouse_client::ID)
-                .memory_account(memory_account)
-                .memory_account_bump(memory_account_bump)
-                .memory_offset(128)
-                .memory_index(0)
+                .memory(memory)
+                .memory_bump(memory_bump)
+                .write_offset(128)
+                .memory_id(0)
                 .system_program(system_program::id())
                 .write_type(WriteType::DataValue(DataValue::Pubkey(
                     random_keypair.encodable_pubkey(),
                 )))
                 .instruction(),
             AssertAccountDataBuilder::new()
-                .target_account(memory_account)
+                .target_account(memory)
                 .log_level(lighthouse_client::types::LogLevel::Silent)
                 .assertion(DataValueAssertion::U64 {
                     value: u64::MAX / 2,
@@ -341,7 +341,7 @@ async fn test_write_u64() {
                 .offset(0)
                 .instruction(),
             AssertAccountDataBuilder::new()
-                .target_account(memory_account)
+                .target_account(memory)
                 .log_level(lighthouse_client::types::LogLevel::Silent)
                 .assertion(DataValueAssertion::Pubkey {
                     value: random_keypair.encodable_pubkey(),
@@ -350,7 +350,7 @@ async fn test_write_u64() {
                 .offset(128)
                 .instruction(),
             AssertAccountDataBuilder::new()
-                .target_account(memory_account)
+                .target_account(memory)
                 .log_level(lighthouse_client::types::LogLevel::Silent)
                 .assertion(DataValueAssertion::U128 {
                     value: u128::MAX,

--- a/tests/lighthouse/tests/utils/mod.rs
+++ b/tests/lighthouse/tests/utils/mod.rs
@@ -22,13 +22,6 @@ use solana_sdk::{
 };
 use std::result;
 
-pub fn find_memory(user: Pubkey, memory_id: u8) -> (solana_program::pubkey::Pubkey, u8) {
-    solana_program::pubkey::Pubkey::find_program_address(
-        &["memory".to_string().as_ref(), user.as_ref(), &[memory_id]],
-        &lighthouse_client::ID,
-    )
-}
-
 use self::{
     context::{TestContext, DEFAULT_LAMPORTS_FUND_AMOUNT},
     error::Error,

--- a/tests/lighthouse/tests/utils/mod.rs
+++ b/tests/lighthouse/tests/utils/mod.rs
@@ -22,13 +22,9 @@ use solana_sdk::{
 };
 use std::result;
 
-pub fn find_memory_account(user: Pubkey, memory_index: u8) -> (solana_program::pubkey::Pubkey, u8) {
+pub fn find_memory(user: Pubkey, memory_id: u8) -> (solana_program::pubkey::Pubkey, u8) {
     solana_program::pubkey::Pubkey::find_program_address(
-        &[
-            "memory".to_string().as_ref(),
-            user.as_ref(),
-            &[memory_index],
-        ],
+        &["memory".to_string().as_ref(), user.as_ref(), &[memory_id]],
         &lighthouse_client::ID,
     )
 }
@@ -466,6 +462,24 @@ pub async fn set_account_from_rpc(
     let mut shared_account =
         AccountSharedData::new(account.lamports, account.data.len(), &account.owner);
     shared_account.set_data_from_slice(account.data.as_slice());
+
+    context
+        .program_context
+        .set_account(account_pubkey, &shared_account);
+}
+
+pub async fn set_account_from_refs(
+    context: &mut TestContext,
+    account_pubkey: &Pubkey,
+    data: &[u8],
+    owner: &Pubkey,
+) {
+    let lamports = context
+        .get_minimum_balance_for_rent_exemption(data.len())
+        .await;
+
+    let mut shared_account = AccountSharedData::new(lamports, data.len(), owner);
+    shared_account.set_data_from_slice(data);
 
     context
         .program_context

--- a/tests/test-client/src/main.rs
+++ b/tests/test-client/src/main.rs
@@ -1,7 +1,7 @@
 use anchor_spl::associated_token;
 use borsh::BorshDeserialize;
 use clap::{Parser, Subcommand};
-use lighthouse_client::get_memory;
+use lighthouse_client::find_memory_pda;
 use lighthouse_client::instructions::{
     AssertAccountDeltaBuilder, AssertAccountInfoBuilder, AssertStakeAccountBuilder,
     MemoryCloseBuilder, MemoryWriteBuilder,
@@ -229,7 +229,7 @@ fn build_safe_send_token_transaction(
     destination_user: &Pubkey,
 ) -> Transaction {
     let token_account = get_associated_token_address(&wallet_keypair.pubkey(), mint);
-    let (memory, memory_bump) = get_memory(wallet_keypair.pubkey(), 0);
+    let (memory, memory_bump) = find_memory_pda(wallet_keypair.pubkey(), 0);
     let dest_token_account = get_associated_token_address(destination_user, mint);
 
     let tx = Transaction::new_signed_with_payer(

--- a/tests/test-client/src/main.rs
+++ b/tests/test-client/src/main.rs
@@ -1,7 +1,7 @@
 use anchor_spl::associated_token;
 use borsh::BorshDeserialize;
 use clap::{Parser, Subcommand};
-use lighthouse_client::get_memory_account;
+use lighthouse_client::get_memory;
 use lighthouse_client::instructions::{
     AssertAccountDeltaBuilder, AssertAccountInfoBuilder, AssertStakeAccountBuilder,
     MemoryCloseBuilder, MemoryWriteBuilder,
@@ -229,7 +229,7 @@ fn build_safe_send_token_transaction(
     destination_user: &Pubkey,
 ) -> Transaction {
     let token_account = get_associated_token_address(&wallet_keypair.pubkey(), mint);
-    let (memory_account, memory_account_bump) = get_memory_account(wallet_keypair.pubkey(), 0);
+    let (memory, memory_bump) = get_memory(wallet_keypair.pubkey(), 0);
     let dest_token_account = get_associated_token_address(destination_user, mint);
 
     let tx = Transaction::new_signed_with_payer(
@@ -237,10 +237,10 @@ fn build_safe_send_token_transaction(
             MemoryWriteBuilder::new()
                 .payer(wallet_keypair.pubkey())
                 .source_account(token_account)
-                .memory_account(memory_account)
-                .memory_index(0)
-                .memory_offset(0)
-                .memory_account_bump(memory_account_bump)
+                .memory(memory)
+                .memory_id(0)
+                .write_offset(0)
+                .memory_bump(memory_bump)
                 .write_type(WriteType::AccountData {
                     offset: 0,
                     data_length: 72,
@@ -256,7 +256,7 @@ fn build_safe_send_token_transaction(
             )
             .unwrap(),
             AssertAccountDeltaBuilder::new()
-                .account_a(memory_account)
+                .account_a(memory)
                 .account_b(token_account)
                 .assertion(AccountDeltaAssertion::Data {
                     a_offset: 0,
@@ -269,7 +269,7 @@ fn build_safe_send_token_transaction(
                 .log_level(LogLevel::Silent)
                 .instruction(),
             AssertAccountDeltaBuilder::new()
-                .account_a(memory_account)
+                .account_a(memory)
                 .account_b(token_account)
                 .assertion(AccountDeltaAssertion::Data {
                     a_offset: 64,
@@ -283,9 +283,9 @@ fn build_safe_send_token_transaction(
                 .instruction(),
             MemoryCloseBuilder::new()
                 .payer(wallet_keypair.pubkey())
-                .memory_account(memory_account)
-                .memory_account_bump(memory_account_bump)
-                .memory_index(0)
+                .memory(memory)
+                .memory_bump(memory_bump)
+                .memory_id(0)
                 .instruction(),
         ],
         Some(&wallet_keypair.pubkey()),


### PR DESCRIPTION
### PR

- Rename 'memory_account' to 'memory' in all applicable areas.

- Remove RPC devnet calls in favor of hardcoded state. 