### PR TITLE
Fix payer not being writable in instruction builder

### DIFF
--- a/clients/js/src/generated/instructions/memoryClose.ts
+++ b/clients/js/src/generated/instructions/memoryClose.ts
@@ -25,8 +25,8 @@ import {
   IInstructionWithAccounts,
   IInstructionWithData,
   ReadonlyAccount,
-  ReadonlySignerAccount,
   WritableAccount,
+  WritableSignerAccount,
 } from '@solana/instructions';
 import { IAccountSignerMeta, TransactionSigner } from '@solana/signers';
 import {
@@ -51,7 +51,7 @@ export type MemoryCloseInstruction<
         ? ReadonlyAccount<TAccountProgramId>
         : TAccountProgramId,
       TAccountPayer extends string
-        ? ReadonlySignerAccount<TAccountPayer>
+        ? WritableSignerAccount<TAccountPayer>
         : TAccountPayer,
       TAccountMemory extends string
         ? WritableAccount<TAccountMemory>
@@ -76,7 +76,7 @@ export type MemoryCloseInstructionWithSigners<
         ? ReadonlyAccount<TAccountProgramId>
         : TAccountProgramId,
       TAccountPayer extends string
-        ? ReadonlySignerAccount<TAccountPayer> &
+        ? WritableSignerAccount<TAccountPayer> &
             IAccountSignerMeta<TAccountPayer>
         : TAccountPayer,
       TAccountMemory extends string
@@ -209,7 +209,7 @@ export function getMemoryCloseInstruction<
   >[0];
   const accounts: Record<keyof AccountMetas, ResolvedAccount> = {
     programId: { value: input.programId ?? null, isWritable: false },
-    payer: { value: input.payer ?? null, isWritable: false },
+    payer: { value: input.payer ?? null, isWritable: true },
     memory: { value: input.memory ?? null, isWritable: true },
   };
 
@@ -272,7 +272,7 @@ export function getMemoryCloseInstructionRaw<
         },
         AccountRole.READONLY
       ),
-      accountMetaWithDefault(accounts.payer, AccountRole.READONLY_SIGNER),
+      accountMetaWithDefault(accounts.payer, AccountRole.WRITABLE_SIGNER),
       accountMetaWithDefault(accounts.memory, AccountRole.WRITABLE),
       ...(remainingAccounts ?? []),
     ],

--- a/clients/js/src/generated/instructions/memoryWrite.ts
+++ b/clients/js/src/generated/instructions/memoryWrite.ts
@@ -27,8 +27,8 @@ import {
   IInstructionWithAccounts,
   IInstructionWithData,
   ReadonlyAccount,
-  ReadonlySignerAccount,
   WritableAccount,
+  WritableSignerAccount,
 } from '@solana/instructions';
 import { IAccountSignerMeta, TransactionSigner } from '@solana/signers';
 import {
@@ -66,7 +66,7 @@ export type MemoryWriteInstruction<
         ? ReadonlyAccount<TAccountSystemProgram>
         : TAccountSystemProgram,
       TAccountPayer extends string
-        ? ReadonlySignerAccount<TAccountPayer>
+        ? WritableSignerAccount<TAccountPayer>
         : TAccountPayer,
       TAccountMemory extends string
         ? WritableAccount<TAccountMemory>
@@ -101,7 +101,7 @@ export type MemoryWriteInstructionWithSigners<
         ? ReadonlyAccount<TAccountSystemProgram>
         : TAccountSystemProgram,
       TAccountPayer extends string
-        ? ReadonlySignerAccount<TAccountPayer> &
+        ? WritableSignerAccount<TAccountPayer> &
             IAccountSignerMeta<TAccountPayer>
         : TAccountPayer,
       TAccountMemory extends string
@@ -177,7 +177,7 @@ export type MemoryWriteInput<
   payer: Address<TAccountPayer>;
   /** Memory account */
   memory: Address<TAccountMemory>;
-  /** System program */
+  /** Account to be written to memory */
   sourceAccount: Address<TAccountSourceAccount>;
   memoryId: MemoryWriteInstructionDataArgs['memoryId'];
   memoryBump: MemoryWriteInstructionDataArgs['memoryBump'];
@@ -200,7 +200,7 @@ export type MemoryWriteInputWithSigners<
   payer: TransactionSigner<TAccountPayer>;
   /** Memory account */
   memory: Address<TAccountMemory>;
-  /** System program */
+  /** Account to be written to memory */
   sourceAccount: Address<TAccountSourceAccount>;
   memoryId: MemoryWriteInstructionDataArgs['memoryId'];
   memoryBump: MemoryWriteInstructionDataArgs['memoryBump'];
@@ -288,7 +288,7 @@ export function getMemoryWriteInstruction<
   const accounts: Record<keyof AccountMetas, ResolvedAccount> = {
     programId: { value: input.programId ?? null, isWritable: false },
     systemProgram: { value: input.systemProgram ?? null, isWritable: false },
-    payer: { value: input.payer ?? null, isWritable: false },
+    payer: { value: input.payer ?? null, isWritable: true },
     memory: { value: input.memory ?? null, isWritable: true },
     sourceAccount: { value: input.sourceAccount ?? null, isWritable: false },
   };
@@ -371,7 +371,7 @@ export function getMemoryWriteInstructionRaw<
           ('11111111111111111111111111111111' as Address<'11111111111111111111111111111111'>),
         AccountRole.READONLY
       ),
-      accountMetaWithDefault(accounts.payer, AccountRole.READONLY_SIGNER),
+      accountMetaWithDefault(accounts.payer, AccountRole.WRITABLE_SIGNER),
       accountMetaWithDefault(accounts.memory, AccountRole.WRITABLE),
       accountMetaWithDefault(accounts.sourceAccount, AccountRole.READONLY),
       ...(remainingAccounts ?? []),
@@ -403,7 +403,7 @@ export type ParsedMemoryWriteInstruction<
     payer: TAccountMetas[2];
     /** Memory account */
     memory: TAccountMetas[3];
-    /** System program */
+    /** Account to be written to memory */
     sourceAccount: TAccountMetas[4];
   };
   data: MemoryWriteInstructionData;

--- a/clients/rust/src/generated/instructions/memory_close.rs
+++ b/clients/rust/src/generated/instructions/memory_close.rs
@@ -36,7 +36,7 @@ impl MemoryClose {
             self.program_id,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_program::instruction::AccountMeta::new(
             self.payer, true,
         ));
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -79,7 +79,7 @@ pub struct MemoryCloseInstructionArgs {
 /// ### Accounts:
 ///
 ///   0. `[]` program_id
-///   1. `[signer]` payer
+///   1. `[writable, signer]` payer
 ///   2. `[writable]` memory
 #[derive(Default)]
 pub struct MemoryCloseBuilder {
@@ -233,7 +233,7 @@ impl<'a, 'b> MemoryCloseCpi<'a, 'b> {
             *self.program_id.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_program::instruction::AccountMeta::new(
             *self.payer.key,
             true,
         ));
@@ -279,7 +279,7 @@ impl<'a, 'b> MemoryCloseCpi<'a, 'b> {
 /// ### Accounts:
 ///
 ///   0. `[]` program_id
-///   1. `[signer]` payer
+///   1. `[writable, signer]` payer
 ///   2. `[writable]` memory
 pub struct MemoryCloseCpiBuilder<'a, 'b> {
     instruction: Box<MemoryCloseCpiBuilderInstruction<'a, 'b>>,

--- a/clients/rust/src/generated/instructions/memory_write.rs
+++ b/clients/rust/src/generated/instructions/memory_write.rs
@@ -19,7 +19,7 @@ pub struct MemoryWrite {
     pub payer: solana_program::pubkey::Pubkey,
     /// Memory account
     pub memory: solana_program::pubkey::Pubkey,
-    /// System program
+    /// Account to be written to memory
     pub source_account: solana_program::pubkey::Pubkey,
 }
 
@@ -45,7 +45,7 @@ impl MemoryWrite {
             self.system_program,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_program::instruction::AccountMeta::new(
             self.payer, true,
         ));
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -95,7 +95,7 @@ pub struct MemoryWriteInstructionArgs {
 ///
 ///   0. `[]` program_id
 ///   1. `[optional]` system_program (default to `11111111111111111111111111111111`)
-///   2. `[signer]` payer
+///   2. `[writable, signer]` payer
 ///   3. `[writable]` memory
 ///   4. `[]` source_account
 #[derive(Default)]
@@ -141,7 +141,7 @@ impl MemoryWriteBuilder {
         self.memory = Some(memory);
         self
     }
-    /// System program
+    /// Account to be written to memory
     #[inline(always)]
     pub fn source_account(&mut self, source_account: solana_program::pubkey::Pubkey) -> &mut Self {
         self.source_account = Some(source_account);
@@ -217,7 +217,7 @@ pub struct MemoryWriteCpiAccounts<'a, 'b> {
     pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// Memory account
     pub memory: &'b solana_program::account_info::AccountInfo<'a>,
-    /// System program
+    /// Account to be written to memory
     pub source_account: &'b solana_program::account_info::AccountInfo<'a>,
 }
 
@@ -233,7 +233,7 @@ pub struct MemoryWriteCpi<'a, 'b> {
     pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// Memory account
     pub memory: &'b solana_program::account_info::AccountInfo<'a>,
-    /// System program
+    /// Account to be written to memory
     pub source_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// The arguments for the instruction.
     pub __args: MemoryWriteInstructionArgs,
@@ -297,7 +297,7 @@ impl<'a, 'b> MemoryWriteCpi<'a, 'b> {
             *self.system_program.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_program::instruction::AccountMeta::new(
             *self.payer.key,
             true,
         ));
@@ -350,7 +350,7 @@ impl<'a, 'b> MemoryWriteCpi<'a, 'b> {
 ///
 ///   0. `[]` program_id
 ///   1. `[]` system_program
-///   2. `[signer]` payer
+///   2. `[writable, signer]` payer
 ///   3. `[writable]` memory
 ///   4. `[]` source_account
 pub struct MemoryWriteCpiBuilder<'a, 'b> {
@@ -407,7 +407,7 @@ impl<'a, 'b> MemoryWriteCpiBuilder<'a, 'b> {
         self.instruction.memory = Some(memory);
         self
     }
-    /// System program
+    /// Account to be written to memory
     #[inline(always)]
     pub fn source_account(
         &mut self,

--- a/clients/rust/src/lib.rs
+++ b/clients/rust/src/lib.rs
@@ -4,7 +4,7 @@ mod generated;
 
 pub use generated::programs::LIGHTHOUSE_ID;
 pub use generated::programs::LIGHTHOUSE_ID as ID;
-use solana_program::pubkey::Pubkey;
+use solana_program::pubkey::{Pubkey, PubkeyError};
 
 pub mod types {
     pub use crate::generated::types::*;
@@ -29,4 +29,38 @@ pub fn find_memory_pda(payer: Pubkey, memory_id: u8) -> (solana_program::pubkey:
         &["memory".to_string().as_ref(), payer.as_ref(), &[memory_id]],
         &crate::ID,
     )
+}
+
+pub fn find_memory_pda_bump_iterate(
+    payer: Pubkey,
+    memory_id: u8,
+    bump_skip: u8,
+    start_bump: Option<u8>,
+) -> Option<(solana_program::pubkey::Pubkey, u8)> {
+    let memory_ref = "memory".to_string();
+    let seeds = [memory_ref.as_ref(), payer.as_ref(), &[memory_id]];
+
+    let mut bump_seed = [start_bump.unwrap_or(std::u8::MAX)];
+    let mut bump_skip = bump_skip as usize;
+
+    for _ in 0..std::u8::MAX {
+        let mut seeds_with_bump = seeds.to_vec();
+        seeds_with_bump.push(&bump_seed);
+        match Pubkey::create_program_address(&seeds_with_bump, &crate::ID) {
+            Ok(address) => {
+                if bump_skip == 0 {
+                    return Some((address, bump_seed[0]));
+                } else {
+                    bump_skip -= 1;
+                }
+            }
+            Err(PubkeyError::InvalidSeeds) => {}
+            _ => break,
+        }
+        bump_seed[0] -= 1;
+
+        println!("bump_seed: {:?}", bump_seed[0])
+    }
+
+    None
 }

--- a/programs/lighthouse/program/lighthouse.json
+++ b/programs/lighthouse/program/lighthouse.json
@@ -23,7 +23,7 @@
         },
         {
           "name": "payer",
-          "isMut": false,
+          "isMut": true,
           "isSigner": true,
           "docs": [
             "Payer account"
@@ -42,7 +42,7 @@
           "isMut": false,
           "isSigner": false,
           "docs": [
-            "System program"
+            "Account to be written to memory"
           ]
         }
       ],
@@ -84,7 +84,7 @@
         },
         {
           "name": "payer",
-          "isMut": false,
+          "isMut": true,
           "isSigner": true,
           "docs": [
             "Payer account"

--- a/programs/lighthouse/program/src/instruction.rs
+++ b/programs/lighthouse/program/src/instruction.rs
@@ -14,7 +14,7 @@ use shank::ShankInstruction;
 pub(crate) enum LighthouseInstruction {
     #[account(0, name = "program_id", desc = "Lighthouse program")]
     #[account(1, name = "system_program", desc = "System program")]
-    #[account(2, name = "payer", desc = "Payer account", signer)]
+    #[account(2, name = "payer", desc = "Payer account", signer, writable)]
     #[account(3, name = "memory", desc = "Memory account", writable)]
     #[account(4, name = "source_account", desc = "Account to be written to memory")]
     MemoryWrite { 
@@ -25,7 +25,7 @@ pub(crate) enum LighthouseInstruction {
     },
 
     #[account(0, name = "program_id", desc = "Lighthouse program")]
-    #[account(1, name = "payer", desc = "Payer account", signer)]
+    #[account(1, name = "payer", desc = "Payer account", signer, writable)]
     #[account(2, name = "memory", desc = "Memory account", writable)]
     MemoryClose { memory_id: u8, memory_bump: u8 },
 

--- a/programs/lighthouse/program/src/processor/memory_close.rs
+++ b/programs/lighthouse/program/src/processor/memory_close.rs
@@ -20,7 +20,10 @@ impl<'a, 'info> MemoryCloseContext<'a, 'info> {
         memory_bump: u8,
     ) -> Result<Self> {
         let lighthouse_program = Program::new_checked(next_account_info(account_iter)?, None)?;
-        let payer = Signer::new_checked(next_account_info(account_iter)?, None)?;
+        let payer = Signer::new_checked(
+            next_account_info(account_iter)?,
+            Some(&vec![AccountValidation::IsWritable]),
+        )?;
 
         let seeds = &Memory::get_seeds(MemorySeeds {
             payer: payer.key,
@@ -53,7 +56,5 @@ pub(crate) fn memory_close(context: &MemoryCloseContext) -> Result<()> {
     close(
         context.memory.info_as_owned(),
         context.payer.info_as_owned(),
-    )?;
-
-    Ok(())
+    )
 }

--- a/programs/lighthouse/program/src/processor/memory_write.rs
+++ b/programs/lighthouse/program/src/processor/memory_write.rs
@@ -34,7 +34,10 @@ impl<'a, 'info> MemoryWriteContext<'a, 'info> {
     ) -> Result<Self> {
         let lighthouse_program = Program::new_checked(next_account_info(account_iter)?, None)?;
         let system_program = Program::new_checked(next_account_info(account_iter).unwrap(), None)?;
-        let payer = Signer::new_checked(next_account_info(account_iter)?, None)?;
+        let payer = Signer::new_checked(
+            next_account_info(account_iter)?,
+            Some(&vec![AccountValidation::IsWritable]),
+        )?;
 
         let seeds = &Memory::get_seeds(MemorySeeds {
             payer: payer.key,
@@ -68,6 +71,7 @@ impl<'a, 'info> MemoryWriteContext<'a, 'info> {
             Memory::new_checked(
                 memory_info,
                 Some(&vec![
+                    AccountValidation::IsProgramOwned(crate::ID),
                     AccountValidation::IsWritable,
                     AccountValidation::IsProgramDerivedAddress {
                         seeds,

--- a/programs/lighthouse/program/src/types/assert/account_delta.rs
+++ b/programs/lighthouse/program/src/types/assert/account_delta.rs
@@ -83,11 +83,11 @@ impl<'a, 'info> Assert<(&'a AccountInfo<'info>, &'a AccountInfo<'info>)> for Acc
                 }
 
                 let a_account_data = a_account.try_borrow_data().map_err(|e| {
-                    err_msg!("Cannot borrow data for left target account", e);
+                    err_msg!("Cannot borrow data for account_a", e);
                     err!(LighthouseError::AccountBorrowFailed)
                 })?;
                 let b_account_data = b_account.try_borrow_data().map_err(|e| {
-                    err_msg!("Cannot borrow data for right target account", e);
+                    err_msg!("Cannot borrow data for account_b", e);
                     err!(LighthouseError::AccountBorrowFailed)
                 })?;
 
@@ -205,7 +205,7 @@ impl<'a, 'info> Assert<(&'a AccountInfo<'info>, &'a AccountInfo<'info>)> for Acc
                 let (a_account, b_account) = accounts;
 
                 let a_account_data = a_account.try_borrow_data().map_err(|e| {
-                    err_msg!("Cannot borrow data for left target account", e);
+                    err_msg!("Cannot borrow data for account_a", e);
                     err!(LighthouseError::AccountBorrowFailed)
                 })?;
 

--- a/programs/lighthouse/program/src/types/assert/log_level.rs
+++ b/programs/lighthouse/program/src/types/assert/log_level.rs
@@ -12,7 +12,7 @@ impl LogLevel {
         self == &LogLevel::Silent
     }
 
-    pub fn is_plaintextmsg_log(&self) -> bool {
+    pub fn is_plaintext_message(&self) -> bool {
         self == &LogLevel::PlaintextMessage
     }
 }

--- a/programs/lighthouse/program/src/types/assert/mint_account.rs
+++ b/programs/lighthouse/program/src/types/assert/mint_account.rs
@@ -34,10 +34,6 @@ pub enum MintAccountAssertion {
 
 impl Assert<&AccountInfo<'_>> for MintAccountAssertion {
     fn evaluate(&self, account: &AccountInfo<'_>, log_level: LogLevel) -> Result<()> {
-        if account.data_is_empty() {
-            return Err(LighthouseError::AccountNotInitialized.into());
-        }
-
         if !keys_equal(account.owner, &spl_token::ID)
             && !keys_equal(account.owner, &spl_token_2022::ID)
         {
@@ -54,11 +50,7 @@ impl Assert<&AccountInfo<'_>> for MintAccountAssertion {
                 value: assertion_value,
                 operator,
             } => {
-                let data_range = 0..36;
-                let data_slice = data
-                    .get(data_range.clone())
-                    .ok_or_else(|| out_of_bounds_err(data_range))?;
-
+                let data_slice = data.get(0..36).ok_or_else(|| out_of_bounds_err(0..36))?;
                 let mint_authority = unpack_coption_key(data_slice)?;
 
                 operator.evaluate(&mint_authority, assertion_value, log_level)
@@ -67,10 +59,7 @@ impl Assert<&AccountInfo<'_>> for MintAccountAssertion {
                 value: assertion_value,
                 operator,
             } => {
-                let data_range = 36..44;
-                let data_slice = data
-                    .get(data_range.clone())
-                    .ok_or_else(|| out_of_bounds_err(data_range))?;
+                let data_slice = data.get(36..44).ok_or_else(|| out_of_bounds_err(36..44))?;
                 let actual_supply = u64::from_le_bytes(data_slice.try_into().map_err(|e| {
                     err_msg!("Failed to deserialize supply from account data", e);
                     err!(LighthouseError::FailedToDeserialize)
@@ -82,10 +71,7 @@ impl Assert<&AccountInfo<'_>> for MintAccountAssertion {
                 value: assertion_value,
                 operator,
             } => {
-                let data_range = 44..45;
-                let data_slice = data
-                    .get(data_range.clone())
-                    .ok_or_else(|| out_of_bounds_err(data_range))?;
+                let data_slice = data.get(44..45).ok_or_else(|| out_of_bounds_err(44..45))?;
                 let actual_decimals = u8::from_le_bytes(data_slice.try_into().map_err(|e| {
                     err_msg!("Failed to deserialize decimals from account data", e);
                     err!(LighthouseError::FailedToDeserialize)
@@ -106,11 +92,7 @@ impl Assert<&AccountInfo<'_>> for MintAccountAssertion {
                 value: assertion_value,
                 operator,
             } => {
-                let data_range = 46..82;
-                let data_slice = data
-                    .get(data_range.clone())
-                    .ok_or_else(|| out_of_bounds_err(data_range))?;
-
+                let data_slice = data.get(46..82).ok_or_else(|| out_of_bounds_err(46..82))?;
                 let freeze_authority = unpack_coption_key(data_slice)?;
 
                 operator.evaluate(&freeze_authority, assertion_value, log_level)

--- a/programs/lighthouse/program/src/types/assert/stake_account.rs
+++ b/programs/lighthouse/program/src/types/assert/stake_account.rs
@@ -37,10 +37,6 @@ pub enum StakeAccountAssertion {
 
 impl Assert<&AccountInfo<'_>> for StakeAccountAssertion {
     fn evaluate(&self, account: &AccountInfo<'_>, log_level: LogLevel) -> Result<()> {
-        if account.data_is_empty() {
-            return Err(LighthouseError::AccountNotInitialized.into());
-        }
-
         if !keys_equal(account.owner, &solana_program::stake::program::ID) {
             return Err(LighthouseError::AccountOwnerMismatch.into());
         }

--- a/programs/lighthouse/program/src/types/assert/token_account.rs
+++ b/programs/lighthouse/program/src/types/assert/token_account.rs
@@ -3,7 +3,7 @@ use crate::{
     err, err_msg,
     error::LighthouseError,
     types::assert::operator::{ComparableOperator, EquatableOperator, Operator},
-    utils::{out_of_bounds_err, unpack_coption_key, unpack_coption_u64, Result},
+    utils::{keys_equal, out_of_bounds_err, unpack_coption_key, unpack_coption_u64, Result},
 };
 use borsh::{BorshDeserialize, BorshSerialize};
 use solana_program::{account_info::AccountInfo, pubkey::Pubkey};
@@ -66,11 +66,9 @@ pub fn u8_from_account_state(state: AccountState) -> u8 {
 
 impl Assert<&AccountInfo<'_>> for TokenAccountAssertion {
     fn evaluate(&self, account: &AccountInfo<'_>, log_level: LogLevel) -> Result<()> {
-        if account.data_is_empty() {
-            return Err(LighthouseError::AccountNotInitialized.into());
-        }
-
-        if ![spl_token::ID, spl_token_2022::ID].contains(account.owner) {
+        if !keys_equal(account.owner, &spl_token::ID)
+            && !keys_equal(account.owner, &spl_token_2022::ID)
+        {
             return Err(LighthouseError::AccountOwnerMismatch.into());
         }
 

--- a/programs/lighthouse/program/src/types/assert/upgradable_loader_state.rs
+++ b/programs/lighthouse/program/src/types/assert/upgradable_loader_state.rs
@@ -107,7 +107,7 @@ impl Assert<&UpgradeableLoaderState> for UpgradableBufferAssertion {
             },
             _ => {
                 msg!(
-                    "Account is not in program state was {}",
+                    "Account is not in buffer state was {}",
                     get_state_enum(upgradable_loader_state)
                 );
                 Err(LighthouseError::AssertionFailed.into())


### PR DESCRIPTION
### PR

- Add writable flag to shank macro for payer for write and close memory instructions

- Add validations that payer needs to be writable in write and close memory instructions.

- Clean up mint assertion evaluate function

- Remove empty account checks for mint, stake, and token assertions

- Fix error log typos