### PR TITLE
Use u64 instead of usize, check program owner for init_if_needed

### DIFF
--- a/configs/scripts/program/test.sh
+++ b/configs/scripts/program/test.sh
@@ -24,7 +24,7 @@ export SBF_OUT_DIR="${WORKING_DIR}/${OUTPUT}"
 
 cd ${WORKING_DIR}/programs/lighthouse/program
 echo "Running solana test-sbf for ${p}..."
-RUST_LOG=error BPF_OUT_DIR=${WORKING_DIR}/configs/.programs cargo test 2>&1
+RUST_LOG=error RUST_BACKTRACE=1 BPF_OUT_DIR=${WORKING_DIR}/configs/.programs cargo test 2>&1
 
-cd ${WORKING_DIR}/tests/lighthouse
-RUST_LOG=error cargo test 2>&1
+cd ${WORKING_DIR}/tests/lighthouse/
+RUST_LOG=error RUST_BACKTRACE=1 cargo test 2>&1

--- a/programs/lighthouse/program/src/processor/memory_write.rs
+++ b/programs/lighthouse/program/src/processor/memory_write.rs
@@ -48,10 +48,10 @@ impl<'a, 'info> MemoryWriteContext<'a, 'info> {
             bump: Some(memory_bump),
         });
 
-        let required_space = (write_offset as usize) + write_type.data_length();
+        let required_space = (write_offset as u64) + write_type.data_length();
 
         let memory_info = next_account_info(account_iter)?;
-        let memory = if memory_info.try_data_len()? < required_space {
+        let memory = if memory_info.try_data_len()? < required_space as usize {
             Memory::new_init_checked(
                 memory_info,
                 InitializeType::InitOrReallocIfNeeded {
@@ -133,8 +133,8 @@ pub(crate) fn memory_write(
                 DataValue::Bytes(value) => value.clone(),
                 DataValue::Pubkey(value) => value.to_bytes().to_vec(),
             };
-            let data_length = write_type.data_length();
 
+            let data_length = write_type.data_length() as usize;
             let memory_write_range = write_offset..(write_offset + data_length);
             let memory_write_slice =
                 memory_ref
@@ -155,7 +155,7 @@ pub(crate) fn memory_write(
             data_length: _,
         } => {
             let data_offset = *data_offset as usize;
-            let data_length = write_type.data_length();
+            let data_length = write_type.data_length() as usize;
 
             let data = source_account.try_borrow_data().map_err(|err| {
                 msg!("Failed to borrow target account: {:?}", err);
@@ -222,8 +222,8 @@ pub(crate) fn memory_write(
                     })?
                 }
             };
-            let data_length = write_type.data_length();
 
+            let data_length = write_type.data_length() as usize;
             let memory_write_range = write_offset..(write_offset + data_length);
             let memory_write_slice =
                 memory_ref
@@ -268,8 +268,7 @@ pub(crate) fn memory_write(
                 })?,
             };
 
-            let data_length = write_type.data_length();
-
+            let data_length = write_type.data_length() as usize;
             let memory_write_range = write_offset..(write_offset + data_length);
             let memory_write_slice =
                 memory_ref

--- a/programs/lighthouse/program/src/types/write/write_type.rs
+++ b/programs/lighthouse/program/src/types/write/write_type.rs
@@ -10,12 +10,12 @@ pub enum WriteType {
 }
 
 impl WriteType {
-    pub fn data_length(&self) -> usize {
+    pub fn data_length(&self) -> u64 {
         match self {
             WriteType::AccountData {
                 offset: _,
                 data_length,
-            } => *data_length as usize,
+            } => *data_length as u64,
             WriteType::AccountInfoField(field) => match field {
                 AccountInfoField::Key => 32,
                 AccountInfoField::Lamports => 8,
@@ -30,7 +30,7 @@ impl WriteType {
                 DataValue::U32(_) | DataValue::I32(_) => 4,
                 DataValue::U64(_) | DataValue::I64(_) => 8,
                 DataValue::U128(_) | DataValue::I128(_) => 16,
-                DataValue::Bytes(bytes) => bytes.len(),
+                DataValue::Bytes(bytes) => bytes.len() as u64,
                 DataValue::Pubkey(_) => 32,
             },
             WriteType::Clock(field) => match field {


### PR DESCRIPTION
### PR

- Use u64 instead of usize in memory datalength / processor.

- Fail if program owner is unexpected for init_if_needed

- Remove broken syscall mock tests